### PR TITLE
feat: drag tasks between columns + UI polish (#6)

### DIFF
--- a/app/board/[id]/page.tsx
+++ b/app/board/[id]/page.tsx
@@ -1,5 +1,6 @@
 // Server Component — fetches the board and guards access before rendering.
 
+import Link from "next/link"
 import { notFound } from "next/navigation"
 import { getBoard } from "@/lib/repositories/board"
 import { getCurrentUserId } from "@/lib/auth"
@@ -20,7 +21,13 @@ export default async function BoardPage({ params }: Props) {
   if (!board) notFound()
 
   return (
-    <main className="mx-auto max-w-5xl px-4 py-12">
+    <main className="px-8 py-12">
+      <Link
+        href="/"
+        className="mb-6 inline-flex items-center gap-1 text-sm text-muted transition-colors hover:text-primary"
+      >
+        ← All boards
+      </Link>
       <h1 className="mb-8 text-2xl font-bold text-primary">{board.title}</h1>
 
       <KanbanBoard boardId={id} />

--- a/app/components/board/BoardCard.tsx
+++ b/app/components/board/BoardCard.tsx
@@ -11,20 +11,22 @@ type Board = {
 
 export default function BoardCard({ board }: { board: Board }) {
   return (
-    <div className="flex items-center justify-between rounded-lg border border-edge bg-surface px-4 py-3 shadow-sm">
-      <Link
-        href={`/board/${board.id}`}
-        className="flex-1 font-medium text-primary hover:underline"
-      >
-        {board.title}
-      </Link>
+    <div className="flex gap-5 items-center justify-between rounded-lg border border-edge bg-surface px-4 py-3 shadow-sm">
+      <div className="flex-1">
+        <Link
+          href={`/board/${board.id}`}
+          className="font-medium text-primary transition-colors hover:text-accent"
+        >
+          {board.title}
+        </Link>
+      </div>
       <div className="flex items-center gap-2">
         <EditBoardModal board={board} />
         <form action={deleteBoardAction}>
           <input type="hidden" name="boardId" value={board.id} />
           <button
             type="submit"
-            className="rounded px-3 py-1 text-sm text-danger hover:text-danger-hover"
+            className="cursor-pointer rounded px-3 py-1 text-sm text-danger transition-colors hover:text-danger-hover"
           >
             Delete
           </button>

--- a/app/components/board/EditBoardModal.tsx
+++ b/app/components/board/EditBoardModal.tsx
@@ -11,7 +11,7 @@ export default function EditBoardModal({ board }: { board: Board }) {
       trigger={(open) => (
         <button
           onClick={open}
-          className="rounded px-3 py-1 text-sm text-secondary hover:text-primary"
+          className="cursor-pointer rounded px-3 py-1 text-sm text-secondary transition-colors hover:text-primary"
         >
           Edit
         </button>

--- a/app/components/board/NewBoardModal.tsx
+++ b/app/components/board/NewBoardModal.tsx
@@ -9,7 +9,7 @@ export default function NewBoardModal() {
       trigger={(open) => (
         <button
           onClick={open}
-          className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+          className="rounded-3xl hover:rounded-xl transition-all hover:cursor-pointer bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
         >
           New board
         </button>

--- a/app/components/kanban/KanbanBoard.tsx
+++ b/app/components/kanban/KanbanBoard.tsx
@@ -1,14 +1,7 @@
 import { getColumnsWithTasks } from "@/lib/repositories/column"
-import KanbanColumn from "@/app/components/kanban/KanbanColumn"
+import KanbanBoardClient from "@/app/components/kanban/KanbanBoardClient"
 
 export default async function KanbanBoard({ boardId }: { boardId: string }) {
   const columns = await getColumnsWithTasks(boardId)
-
-  return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-      {columns.map((column) => (
-        <KanbanColumn key={column.id} boardId={boardId} column={column} />
-      ))}
-    </div>
-  )
+  return <KanbanBoardClient columns={columns} boardId={boardId} />
 }

--- a/app/components/kanban/KanbanBoardClient.tsx
+++ b/app/components/kanban/KanbanBoardClient.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core"
+import KanbanColumn from "@/app/components/kanban/KanbanColumn"
+import { moveTaskAction } from "@/lib/actions/task"
+
+type Task = {
+  id: string
+  title: string
+  description: string | null
+  position: number
+  boardId: string
+  columnId: string
+}
+
+type Column = {
+  id: string
+  title: string
+  position: number
+  tasks: Task[]
+}
+
+export default function KanbanBoardClient({
+  columns,
+  boardId,
+}: {
+  columns: Column[]
+  boardId: string
+}) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      // Require 8px of movement before a drag starts so button clicks inside
+      // cards aren't accidentally treated as drag gestures.
+      activationConstraint: { distance: 8 },
+    })
+  )
+
+  async function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (!over) return
+
+    const taskId = active.id as string
+    const newColumnId = over.id as string
+
+    const sourceColumn = columns.find((col) =>
+      col.tasks.some((t) => t.id === taskId)
+    )
+    if (!sourceColumn || sourceColumn.id === newColumnId) return
+
+    await moveTaskAction(taskId, newColumnId, boardId)
+  }
+
+  return (
+    <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {columns.map((column) => (
+          <KanbanColumn key={column.id} boardId={boardId} column={column} />
+        ))}
+      </div>
+    </DndContext>
+  )
+}

--- a/app/components/kanban/KanbanColumn.tsx
+++ b/app/components/kanban/KanbanColumn.tsx
@@ -17,6 +17,12 @@ type Column = {
   tasks: Task[]
 }
 
+const EMPTY_MESSAGES: Record<string, string> = {
+  "To Do": "No tasks to do yet",
+  "In Progress": "Nothing in progress",
+  "Done": "All caught up",
+}
+
 export default function KanbanColumn({
   column,
   boardId,
@@ -32,9 +38,13 @@ export default function KanbanColumn({
         </h2>
       </div>
       <div className="flex min-h-48 flex-col gap-2 p-2">
-        {column.tasks.map((task) => (
-          <TaskCard key={task.id} task={task} />
-        ))}
+        {column.tasks.length === 0 ? (
+          <p className="m-auto text-xs text-muted">
+            {EMPTY_MESSAGES[column.title] ?? "No tasks yet"}
+          </p>
+        ) : (
+          column.tasks.map((task) => <TaskCard key={task.id} task={task} />)
+        )}
       </div>
       <div className="border-t border-edge p-2">
         <NewTaskModal columnId={column.id} boardId={boardId} />

--- a/app/components/kanban/KanbanColumn.tsx
+++ b/app/components/kanban/KanbanColumn.tsx
@@ -47,7 +47,7 @@ export default function KanbanColumn({
           {column.title}
         </h2>
       </div>
-      <div className="flex min-h-48 flex-col gap-2 p-2">
+      <div className="flex min-h-80 flex-col gap-2 p-3">
         {column.tasks.length === 0 ? (
           <p className="m-auto text-xs text-muted">
             {EMPTY_MESSAGES[column.title] ?? "No tasks yet"}

--- a/app/components/kanban/KanbanColumn.tsx
+++ b/app/components/kanban/KanbanColumn.tsx
@@ -1,3 +1,6 @@
+"use client"
+
+import { useDroppable } from "@dnd-kit/core"
 import TaskCard from "@/app/components/task/TaskCard"
 import NewTaskModal from "@/app/components/task/NewTaskModal"
 
@@ -30,8 +33,15 @@ export default function KanbanColumn({
   column: Column
   boardId: string
 }) {
+  const { setNodeRef, isOver } = useDroppable({ id: column.id })
+
   return (
-    <div className="flex flex-col rounded-lg border border-edge bg-elevated">
+    <div
+      ref={setNodeRef}
+      className={`flex flex-col rounded-lg border bg-elevated transition-colors ${
+        isOver ? "border-accent" : "border-edge"
+      }`}
+    >
       <div className="border-b border-edge px-3 py-2">
         <h2 className="text-xs font-semibold uppercase tracking-wider text-secondary">
           {column.title}

--- a/app/components/task/EditTaskModal.tsx
+++ b/app/components/task/EditTaskModal.tsx
@@ -16,7 +16,7 @@ export default function EditTaskModal({ task }: { task: Task }) {
       trigger={(open) => (
         <button
           onClick={open}
-          className="rounded p-1 text-xs text-muted hover:text-primary"
+          className="cursor-pointer rounded p-1 text-xs text-muted transition-colors hover:text-primary"
         >
           Edit
         </button>

--- a/app/components/task/NewTaskModal.tsx
+++ b/app/components/task/NewTaskModal.tsx
@@ -11,7 +11,7 @@ export default function NewTaskModal({ columnId, boardId }: Props) {
       trigger={(open) => (
         <button
           onClick={open}
-          className="flex w-full items-center gap-1 rounded px-2 py-1 text-xs text-muted hover:text-primary"
+          className="flex w-full cursor-pointer items-center gap-1 rounded px-2 py-1 text-xs text-muted transition-colors hover:text-primary"
         >
           + Add task
         </button>

--- a/app/components/task/TaskCard.tsx
+++ b/app/components/task/TaskCard.tsx
@@ -1,3 +1,7 @@
+"use client"
+
+import { useDraggable } from "@dnd-kit/core"
+import { CSS } from "@dnd-kit/utilities"
 import EditTaskModal from "@/app/components/task/EditTaskModal"
 import { deleteTaskAction } from "@/lib/actions/task"
 
@@ -9,29 +13,54 @@ type Task = {
 }
 
 export default function TaskCard({ task }: { task: Task }) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({ id: task.id })
+
+  const style = transform
+    ? { transform: CSS.Translate.toString(transform) }
+    : undefined
+
   return (
-    <div className="rounded border border-edge bg-surface p-3 shadow-sm">
-      <div className="flex items-start justify-between gap-2">
-        <p className="text-sm font-medium text-primary">{task.title}</p>
-        <div className="flex shrink-0 items-center gap-1">
-          <EditTaskModal task={task} />
-          <form action={deleteTaskAction}>
-            <input type="hidden" name="taskId" value={task.id} />
-            <input type="hidden" name="boardId" value={task.boardId} />
-            <button
-              type="submit"
-              className="rounded p-1 text-xs text-muted hover:text-danger"
-            >
-              ✕
-            </button>
-          </form>
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`rounded border border-edge bg-surface p-3 shadow-sm ${
+        isDragging ? "opacity-50" : ""
+      }`}
+    >
+      <div className="flex items-start gap-2">
+        <button
+          {...listeners}
+          {...attributes}
+          aria-label="Drag task"
+          className="mt-0.5 shrink-0 cursor-grab text-muted active:cursor-grabbing hover:text-secondary"
+        >
+          ⠿
+        </button>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            <p className="text-sm font-medium text-primary">{task.title}</p>
+            <div className="flex shrink-0 items-center gap-1">
+              <EditTaskModal task={task} />
+              <form action={deleteTaskAction}>
+                <input type="hidden" name="taskId" value={task.id} />
+                <input type="hidden" name="boardId" value={task.boardId} />
+                <button
+                  type="submit"
+                  className="rounded p-1 text-xs text-muted hover:text-danger"
+                >
+                  ✕
+                </button>
+              </form>
+            </div>
+          </div>
+          {task.description && (
+            <p className="mt-1 text-xs text-secondary line-clamp-2">
+              {task.description}
+            </p>
+          )}
         </div>
       </div>
-      {task.description && (
-        <p className="mt-1 text-xs text-secondary line-clamp-2">
-          {task.description}
-        </p>
-      )}
     </div>
   )
 }

--- a/app/components/task/TaskCard.tsx
+++ b/app/components/task/TaskCard.tsx
@@ -47,7 +47,7 @@ export default function TaskCard({ task }: { task: Task }) {
                 <input type="hidden" name="boardId" value={task.boardId} />
                 <button
                   type="submit"
-                  className="rounded p-1 text-xs text-muted hover:text-danger"
+                  className="cursor-pointer rounded p-1 text-xs text-muted transition-colors hover:text-danger"
                 >
                   ✕
                 </button>

--- a/app/components/ui/Modal.tsx
+++ b/app/components/ui/Modal.tsx
@@ -17,7 +17,7 @@ export const Modal = ({ isOpen, onClose, title, children }: ModalProps) => {
           <h3 className="text-lg font-semibold text-primary">{title || 'Modal'}</h3>
           <button
             onClick={onClose}
-            className="text-muted hover:text-primary"
+            className="cursor-pointer text-muted transition-colors hover:text-primary"
           >
             ✕
           </button>

--- a/app/components/ui/ModalForm.tsx
+++ b/app/components/ui/ModalForm.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React from "react"
+import React, { useState } from "react"
 import { Modal } from "@/app/components/ui/Modal"
 import { useModal } from "@/lib/hooks/useModal"
 
@@ -20,30 +20,53 @@ export function ModalForm({
   children,
 }: ModalFormProps) {
   const { isOpen, open, close } = useModal()
+  const [error, setError] = useState<string | null>(null)
+
+  function handleClose() {
+    setError(null)
+    close()
+  }
 
   async function handleSubmit(formData: FormData) {
-    await action(formData)
-    close()
+    setError(null)
+    try {
+      await action(formData)
+      close()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong. Please try again.")
+    }
   }
 
   return (
     <>
       {trigger(open)}
 
-      <Modal isOpen={isOpen} onClose={close} title={title}>
+      <Modal isOpen={isOpen} onClose={handleClose} title={title}>
         <form action={handleSubmit} className="flex flex-col gap-4">
           {children}
+          {error && (
+            <div className="flex items-start justify-between gap-2 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">
+              <span>{error}</span>
+              <button
+                type="button"
+                onClick={() => setError(null)}
+                className="shrink-0 text-danger/70 hover:text-danger"
+              >
+                ✕
+              </button>
+            </div>
+          )}
           <div className="flex justify-end gap-2">
             <button
               type="button"
-              onClick={close}
-              className="rounded-lg px-4 py-2 text-sm text-secondary hover:text-primary"
+              onClick={handleClose}
+              className="hover:cursor-pointer px-4 py-2 text-sm text-secondary hover:text-primary"
             >
               Cancel
             </button>
             <button
               type="submit"
-              className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+              className="rounded-2xl hover:rounded-xl transition-all hover:cursor-pointer bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
             >
               {submitLabel}
             </button>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ export default async function HomePage() {
   const boards = await getBoardsByUser(userId)
 
   return (
-    <main className="mx-auto max-w-2xl px-4 py-12">
+    <main className="px-8 py-12">
       <h1 className="mb-6 text-2xl font-bold text-primary">My Boards</h1>
 
       <div className="mb-8">

--- a/lib/actions/task.ts
+++ b/lib/actions/task.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache"
 import { getCurrentUserId } from "@/lib/auth"
-import { createTask, updateTask, deleteTask } from "@/lib/repositories/task"
+import { createTask, updateTask, deleteTask, moveTask } from "@/lib/repositories/task"
 
 export async function createTaskAction(formData: FormData) {
   const userId = await getCurrentUserId()
@@ -39,5 +39,15 @@ export async function deleteTaskAction(formData: FormData) {
   const boardId = formData.get("boardId") as string
 
   await deleteTask(userId, taskId)
+  revalidatePath(`/board/${boardId}`)
+}
+
+export async function moveTaskAction(
+  taskId: string,
+  newColumnId: string,
+  boardId: string
+) {
+  const userId = await getCurrentUserId()
+  await moveTask(userId, taskId, newColumnId)
   revalidatePath(`/board/${boardId}`)
 }

--- a/lib/repositories/task.ts
+++ b/lib/repositories/task.ts
@@ -66,3 +66,30 @@ export async function reorderTask(
     data: { position: newPosition },
   })
 }
+
+export async function moveTask(
+  userId: string,
+  taskId: string,
+  newColumnId: string
+) {
+  const task = await db.task.findFirst({
+    where: { id: taskId, column: { board: { userId } } },
+  })
+  if (!task) throw new Error("Task not found or access denied")
+
+  const newColumn = await db.column.findFirst({
+    where: { id: newColumnId, boardId: task.boardId },
+  })
+  if (!newColumn) throw new Error("Column not found")
+
+  const last = await db.task.findFirst({
+    where: { columnId: newColumnId },
+    orderBy: { position: "desc" },
+  })
+  const position = last ? last.position + 1.0 : 1.0
+
+  return db.task.update({
+    where: { id: taskId },
+    data: { columnId: newColumnId, position },
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "todo",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/utilities": "^3.2.2",
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
         "next": "16.2.4",
@@ -278,6 +280,45 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@electric-sql/pglite": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/utilities": "^3.2.2",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "next": "16.2.4",


### PR DESCRIPTION
## Summary

- **Drag between columns** — `@dnd-kit/core` wraps the board; `KanbanBoardClient` (new client component) owns `DndContext` and `onDragEnd`; `KanbanBoard` stays a Server Component
- **`KanbanColumn`** — `useDroppable`, accent border highlights on drag-over
- **`TaskCard`** — `useDraggable` with isolated ⠿ drag handle; 8px activation constraint keeps Edit/Delete clicks working; card dims on drag
- **`moveTask`** repository + `moveTaskAction` server action — updates `columnId` and appends task to end of target column
- **Full-width layout** — removed `max-w` cap on both pages; both use `px-8` so the left edge lines up on transition; columns grow to `min-h-80`
- **Interaction polish** — `cursor-pointer` + `transition-colors` on every button; back button on board page; board title highlights to accent on hover

Also includes #7 (empty states + ModalForm error handling).

## Test plan

- [ ] `npm run dev` — drag a task card via the ⠿ handle into a different column; verify it persists after refresh
- [ ] Drop on the same column → nothing happens
- [ ] Edit / Delete buttons inside a card still work during a drag session
- [ ] Accent border appears on the target column while dragging over it
- [ ] Empty state message shows in columns with no tasks
- [ ] Back button on board page returns to the boards list
- [ ] Both pages use the same left-edge padding on wide screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)